### PR TITLE
Improve timestamp handling for accurate logs

### DIFF
--- a/client/tcpclient.cpp
+++ b/client/tcpclient.cpp
@@ -36,13 +36,20 @@ TCPClient::TCPClient(std::string name, int port, int interval)
 
 void TCPClient::start() {
     while (true) {
-        time_t now = time(0);
-        struct tm *ltm = localtime(&now);
+        auto now = std::chrono::system_clock::now();
+        std::time_t now_time = std::chrono::system_clock::to_time_t(now);
+        struct tm ltm{};
+        localtime_r(&now_time, &ltm);
+        int ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                     now.time_since_epoch())
+                     .count() %
+                 1000;
 
         char timestamp[64];
-        snprintf(timestamp, sizeof(timestamp), "[%d-%02d-%02d %02d:%02d:%02d.%03d] ",
-                 1900 + ltm->tm_year, 1 + ltm->tm_mon, ltm->tm_mday,
-                 ltm->tm_hour, ltm->tm_min, ltm->tm_sec, 0);
+        snprintf(timestamp, sizeof(timestamp),
+                 "[%d-%02d-%02d %02d:%02d:%02d.%03d] ",
+                 1900 + ltm.tm_year, 1 + ltm.tm_mon, ltm.tm_mday, ltm.tm_hour,
+                 ltm.tm_min, ltm.tm_sec, ms);
 
         std::string message = std::string(timestamp) + name_;
         send(client_socket_, message.c_str(), message.size(), 0);

--- a/server/tcpserver.cpp
+++ b/server/tcpserver.cpp
@@ -4,6 +4,7 @@
 #include <thread>
 #include <mutex>
 #include <ctime>
+#include <chrono>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <unistd.h>
@@ -34,12 +35,20 @@ void handleClient(const int client_socket) {
 
     while ((bytes_read = read(client_socket, buffer, sizeof(buffer) - 1)) > 0) {
         buffer[bytes_read] = '\0';
-        time_t now = time(0);
-        struct tm *ltm = localtime(&now);
+
+        auto now = std::chrono::system_clock::now();
+        std::time_t now_time = std::chrono::system_clock::to_time_t(now);
+        struct tm ltm{};
+        localtime_r(&now_time, &ltm);
+        int ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                     now.time_since_epoch())
+                     .count() %
+                 1000;
         char timestamp[64];
-        snprintf(timestamp, sizeof(timestamp), "[%d-%02d-%02d %02d:%02d:%02d.%03d] ",
-                 1900 + ltm->tm_year, 1 + ltm->tm_mon, ltm->tm_mday,
-                 ltm->tm_hour, ltm->tm_min, ltm->tm_sec, 0);
+        snprintf(timestamp, sizeof(timestamp),
+                 "[%d-%02d-%02d %02d:%02d:%02d.%03d] ",
+                 1900 + ltm.tm_year, 1 + ltm.tm_mon, ltm.tm_mday, ltm.tm_hour,
+                 ltm.tm_min, ltm.tm_sec, ms);
         logMessage(std::string(timestamp) + buffer);
     }
 


### PR DESCRIPTION
## Summary
- compute and log real millisecond precision timestamps using `std::chrono`
- use thread-safe `localtime_r` when building log entries

## Testing
- `g++ -std=c++11 -o Server server/server.cpp server/tcpserver.cpp -pthread`
- `g++ -std=c++11 -o Client client/client.cpp client/tcpclient.cpp -pthread`


------
https://chatgpt.com/codex/tasks/task_e_68a7862a01f0832798d4e43304201394